### PR TITLE
Fix pip install syntax in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ COPY ./requirements.txt /app/requirements.txt
 WORKDIR /app
 
 # install the dependencies and packages in the requirements file
-RUN pip install -r requirements.txt gunicorn>=20.1.0 psycopg2>2.9
+RUN pip install -r requirements.txt "gunicorn>=20.1.0" "psycopg2>2.9"
 
 # copy every content from the local file to the image
 COPY . /app


### PR DESCRIPTION
pip install abc>1.2.3 causes pip to install abc and forward log into
file 1.2.3. Instead we need to quote deps.
