### PR TITLE
Display open incidents on index page

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -90,11 +90,20 @@ nav.navbar {
     background-color: var(--bs-red);
     border: 2px solid var(--bs-red);
 }
+.alert-outage .alert-link {
+    color: var(--bs-dark)
+}
 .alert-major {
     border: 2px solid var(--bs-orange);
 }
+.alert-major .alert-link {
+    color: var(--bs-orange)
+}
 .alert-minor {
-    border: 2px solid var(--bs-yellow);
+    border: 2px solid var(--bs-cyan);
+}
+.alert-minor .alert-link {
+    color: var(--bs-cyan)
 }
 .alert-maintenance {
     border: 2px solid var(--bs-blue);

--- a/app/web/routes.py
+++ b/app/web/routes.py
@@ -70,6 +70,7 @@ def new_incident(current_user):
         )
         db.session.add(incident)
         db.session.commit()
+        return redirect("/")
     return render_template(
         "create_incident.html", title="Open Incident", form=form
     )
@@ -100,7 +101,7 @@ def post_incident_update(incident_id):
         )
         db.session.add(update)
         db.session.commit()
-    return redirect(url_for("web.incident", id=incident_id))
+    return redirect(url_for("web.incident", incident_id=incident_id))
 
 
 @bp.route("/login/<name>")

--- a/app/web/templates/incident.html
+++ b/app/web/templates/incident.html
@@ -4,11 +4,11 @@
 <div class="container">
 
   <h4>{{ incident.text }}</h4>
-  <h6 class="alert-regions">Affected Regions: {{
+  <h6>Affected Regions: {{
       incident.get_attributes_by_key('region')
       | join(', ')
       }}</h6>
-  <h6 class="alert-services">Affected Services: {{
+  <h6>Affected Services: {{
       incident.components.all()
       | map(attribute='name')
       | unique

--- a/app/web/templates/index.html
+++ b/app/web/templates/index.html
@@ -2,9 +2,50 @@
 
 {% block content %}
 <div class="container">
+  {% set open_incidents = incidents.open().all() %}
+  {% if open_incidents | length == 0 %}
+    <div class="alert alert-success" role="alert">
+      All systems running
+    </div>
+  {% else %}
+    {% for incident in open_incidents | sort(attribute='start_date', reverse = True) %}
+      <div class="alert alert-{{incident.impact.value}}" role="alert">
+          <h4 class="alert-heading">
+              <a class="alert-link"
+                  href="incidents/{{incident.id}}">{{incident.impact.value|capitalize}}: {{ incident.text }}</a>
+        </h4>
+        <h6>Affected Regions: {{
+            incident.get_attributes_by_key('region')
+            | join(', ')
+            }}</h6>
+        <h6>Affected Services: {{
+            incident.components.all()
+            | map(attribute='name')
+            | join(', ')
+            }}</h6>
+        <small>Start: {{ incident.start_date.strftime('%Y-%m-%dT%H:%M') }}</small>
+        <hr/>
+        <div class="container text-left">
+        {% for update in incident.updates %}
+          <div class="row">
+              <div class="col-md-2">
+                  <h6>{{ update.status }}</h6>
+                  <small>{{ update.timestamp.strftime('%Y-%m-%d %H:%M') }}</small>
+              </div>
+              <div class="col-md-10">
+                  {{ update.text }}
+              </div>
+              <hr/>
+           </div>
+        {% endfor %}
+        </div>
+      </div>
+    {% endfor %}
+  {% endif %}
+
+<div class="container">
   {% set regions = component_attributes.get_unique_values('region') %}
   {% set all_components_with_incidents = components.query_all_with_active_incidents().all() %}
-  {% set open_incidents = incidents.open().first() %}
   <!-- Nav tabs -->
   <ul class="nav nav-tabs justify-content-center" id="myTab" role="tablist">
     {% for region in regions %}


### PR DESCRIPTION
- currently open incidents are now visible on the index page
- reroute user to '/' after creating a new incident (issue 28)