### PR TITLE
fix(ui): Return incident update form feedback

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -41,7 +41,7 @@ def create_app(test_config=None):
     app = Flask(__name__, instance_relative_config=True)
     app.config.from_object(DefaultConfiguration)
 
-    api = Api(app) # noqa
+    api = Api(app)  # noqa
 
     app.config.from_prefixed_env(prefix="SDB")
 
@@ -61,10 +61,10 @@ def create_app(test_config=None):
         # TODO(gtema): sooner or later this should be dropped
         app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///example.sqlite"
 
-    config_file = pathlib.Path(app.instance_path, 'catalog.yaml')
+    config_file = pathlib.Path(app.instance_path, "catalog.yaml")
     if config_file.exists():
-        with open(config_file, 'r') as fd:
-            app.config['CATALOG'] = yaml.safe_load(fd)
+        with open(config_file, "r") as fd:
+            app.config["CATALOG"] = yaml.safe_load(fd)
 
     # ensure the instance folder exists
     try:

--- a/app/api/__init__.py
+++ b/app/api/__init__.py
@@ -14,4 +14,4 @@ from flask_smorest import Blueprint
 
 bp = Blueprint("api", __name__)
 
-from app.api import routes # noqa
+from app.api import routes  # noqa

--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -42,8 +42,7 @@ class ApiComponentStatus(MethodView):
         attribute = {attribute_name: attribute_value}
         if attribute_name is not None and attribute_value is not None:
             target_component = Component.find_by_name_and_attributes(
-                name,
-                attribute
+                name, attribute
             )
             if target_component is None:
                 abort(404, message="Component does not exist")
@@ -69,11 +68,10 @@ class ApiComponentStatus(MethodView):
         impact = data.get("impact", "minor")
         attributes = dict()
         # Map attributes from {name:k, value:v} into k:v
-        for attr in data.get('attributes', []):
-            attributes[attr.get('name')] = attr.get('value')
+        for attr in data.get("attributes", []):
+            attributes[attr.get("name")] = attr.get("value")
         target_component = Component.find_by_name_and_attributes(
-            name,
-            attributes
+            name, attributes
         )
         if not target_component:
             abort(409, message="Component not found")
@@ -102,7 +100,7 @@ class ApiComponentStatus(MethodView):
                 return incident
             else:
                 # For the component incident is already open - do nothing
-                current_app.logging.debug(
+                current_app.logger.debug(
                     "Active incident for {component} - not opening new "
                     "incident"
                 )
@@ -114,7 +112,7 @@ class ApiComponentStatus(MethodView):
                 text=f"{impact} Incident",
                 impact=impact,
                 start_date=datetime.now(),
-                components=[target_component]
+                components=[target_component],
             )
             db.session.add(new_incident)
             db.session.commit()

--- a/app/api/schemas/components.py
+++ b/app/api/schemas/components.py
@@ -43,14 +43,7 @@ class ComponentSchema(Schema):
 class ComponentStatusArgsSchema(Schema):
     impact = fields.String(
         required=True,
-        validate=validate.OneOf(
-            [
-                "maintenance",
-                "minor",
-                "major",
-                "outage"
-            ]
-        )
+        validate=validate.OneOf(["maintenance", "minor", "major", "outage"]),
     )
     name = fields.String(required=True)
     attributes = fields.List(fields.Nested(ComponentAttributeSchema))

--- a/app/cli.py
+++ b/app/cli.py
@@ -42,7 +42,7 @@ def register(app):
         if "CATALOG" not in app.config:
             return
 
-        for target_component in app.config["CATALOG"]['components']:
+        for target_component in app.config["CATALOG"]["components"]:
             target_attrs = target_component.get("attributes", {})
             if not Component.find_by_name_and_attributes(
                 target_component["name"], target_attrs

--- a/app/default_settings.py
+++ b/app/default_settings.py
@@ -11,6 +11,7 @@
 # under the License.
 #
 
+
 class DefaultConfiguration:
     API_TITLE = "Status Dashboard API"
     API_VERSION = "v1"
@@ -20,3 +21,16 @@ class DefaultConfiguration:
     SECRET_KEY = "dev"
     SQLALCHEMY_ECHO = False
     JSON_SORT_KEYS = True
+
+    MAINTENANCE_STATUSES = {
+        "scheduled": "Maintenance scheduled",
+        "in progress": "Maintenance is in progress",
+        "completed": "Maintenance is successfully completed",
+    }
+
+    INCIDENT_STATUSES = {
+        "analyzing": "Analyzing incident (problem not known yet)",
+        "fixing": "Fixing incident(problem identified, working on fix)",
+        "observing": "Observing fix (fix deployed, watching recovery)",
+        "resolved": "Incident Resolved (service is fully available. Done)",
+    }

--- a/app/models.py
+++ b/app/models.py
@@ -212,12 +212,12 @@ class Incident(db.Model):
                 Incident.start_date <= datetime.datetime.now(),
                 # not closed
                 Incident.end_date.is_(None),
-                Incident.impact == "maintenance"
+                Incident.impact == "maintenance",
             )
         return Incident.query.filter(
             Incident.start_date <= datetime.datetime.now(),
             Incident.end_date.is_(None),
-            Incident.impact != "maintenance"
+            Incident.impact != "maintenance",
         )
 
     @staticmethod

--- a/app/web/templates/incident.html
+++ b/app/web/templates/incident.html
@@ -38,27 +38,41 @@
 
   {% if form %}
     <div class="incident-update-form mt-4">
-      <form action="/incidents/{{incident.id}}/update" method="POST" novalidate>
+      <form action="/incidents/{{incident.id}}" method="POST" novalidate>
       {{ form.hidden_tag() }}
       <div class="mb-3">
         <label for="{{form.update_text.id}}" class="form-label">{{form.update_text.label}}</label>
-        <textarea class="form-control" 
+        <textarea class="form-control
+                         {% if form.update_text.errors %}is-invalid{% endif %}
+                         " 
                id="{{form.update_text.id}}"
                name="{{form.update_text.name}}"
                rows=3
                aria-describedby="updateTextHelp"></textarea>
          <div id="updateTextHelp" class="form-text">Please enter update message
         here.</div>
+        {% if form.update_text.errors %}
+        <div class="invalid-feedback">
+          <ul class="errors">
+            {% for error in form.update_text.errors %}
+               <li>{{ error }}</li>
+            {% endfor %}
+          </ul>
+        </div>
+        {% endif %}
+
       </div>
 
       <div class="mb-3">
         <label for="{{form.update_status.id}}" class="form-label">{{form.update_status.label}}</label>
         <select 
-            class="form-select form-select-sm mb-3"
+            class="form-select form-select-sm mb-3
+                   {% if form.update_status.errors %}is-invalid{% endif %}
+                    "
             aria-label=".form-select-sm" 
             id="{{form.update_status.id}}"
             name="{{form.update_status.name}}">
-          <option selected>Choose...</option>
+          <option>Choose...</option>
           {% for (k, v) in form.update_status.choices %}
           <option value="{{k}}">{{v}}</option>
           {% endfor %}
@@ -66,18 +80,38 @@
 
         <div id="updateStatusHelp" class="form-text">Please enter update status
         here.</div>
+        {% if form.update_status.errors %}
+        <div class="invalid-feedback">
+          <ul class="errors">
+            {% for error in form.update_status.errors %}
+               <li>{{ error }}</li>
+            {% endfor %}
+          </ul>
+        </div>
+        {% endif %}
 
       </div>
 
       <div class=mb-3">
         <label for="{{form.next_update.id}}" class="form-label">{{form.next_update.label}}</label>
-        <input class="form-control" type="datetime"
+        <input class="form-control
+                      {% if form.next_update.errors %}is-invalid{% endif %}
+                      " type="datetime"
                id="{{form.next_update.id}}"
                name="{{form.next_update.name}}"
                aria-describedby="nextUpdateHelp"
                placeholder="2023-01-01 12:34:56"/>
          <div id="nextUpdateHelp" class="form-text">Next update is expected by
            (%Y-%m-%d %H:%M:%S).</div>
+         {% if form.next_update.errors %}
+         <div class="invalid-feedback">
+           <ul class="errors">
+           {% for error in form.next_update.errors %}
+              <li>{{ error }}</li>
+           {% endfor %}
+           </ul>
+         </div>
+         {% endif %}
       </div>
 
       <button type="submit" class="btn btn-primary">Submit</button>


### PR DESCRIPTION
Turn back lost feedback on the form update validation. This actually
forced to move back that update functionality into the incident POST
method. With this change also update_status field values can be defined
through config and only statuses mathing the incident type will be
shown.
