### PR TITLE
routes.py (api) changes

### DIFF
--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -256,7 +256,7 @@ class ApiComponentStatus(MethodView):
         comp_attributes = target_component.attributes
         comp_attributes_str = ", ".join(
             [
-                f"{attr.name}: {attr.value}" for attr in comp_attributes
+                f"{attr.value}" for attr in comp_attributes
             ]
         )
         comp_with_attrs = f"{comp_name} ({comp_attributes_str})"


### PR DESCRIPTION
Fixed a bug "if there was more than one component in an incident, when transferring a higher impact for a component, it was not removed from the incident with a lower impact when a new incident was opened"