### PR TITLE
Add maintenance description

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -192,6 +192,10 @@ tbody:nth-child(odd) {
   background-color: var(--bs-red) !important;
 }
 
+.indent {
+  margin-left: 30px;
+}
+
 
 /* Footer */
 footer.footer {

--- a/app/web/forms.py
+++ b/app/web/forms.py
@@ -71,6 +71,13 @@ class IncidentForm(FlaskForm):
             validators.Length(min=8, max=200),
         ],
     )
+    incident_desc = TextAreaField(
+        "Maintenance description",
+        validators=[
+            validators.Optional(),
+            validators.Length(min=8, max=500),
+        ],
+    )
     incident_impact = SelectField("Incident Impact")
     incident_components = SelectField("Affected services")
     incident_start = DateTimeField(

--- a/app/web/routes.py
+++ b/app/web/routes.py
@@ -109,6 +109,15 @@ def new_incident(current_user):
         db.session.add(new_incident)
         db.session.commit()
 
+        if form.incident_impact.data == "0" and form.incident_desc.data:
+            add_desc = IncidentStatus(
+                incident_id=new_incident.id,
+                text=form.incident_desc.data,
+                status="description",
+            )
+            db.session.add(add_desc)
+            db.session.commit()
+
         current_app.logger.debug(
             f"{new_incident} opened by {get_user_string(current_user)}"
         )

--- a/app/web/templates/create_incident.html
+++ b/app/web/templates/create_incident.html
@@ -46,6 +46,25 @@
         }}</div>
     </div>
 
+    <div id="maintenance_desc" class="mb-3"
+      {% if form.incident_impact.data and "0" in form.incident_impact.data %}
+        style="display: block;"
+      {% else %}
+        style="display: none;"
+      {% endif %}>
+      <label for="{{form.incident_desc.id}}" class="form-label">{{form.incident_desc.label}}</label>
+      <textarea class="form-control {{ ' is-invalid' if form.incident_desc.errors
+                        | length > 0 else '' }}"
+             id="{{form.incident_desc.id}}"
+             name="{{form.incident_desc.name}}"
+             rows=3
+             aria-describedby="incidentTextHelp">{{ form.incident_desc.data if form.incident_desc.data }}</textarea>
+       <div id="incidentTextHelp" class="form-text">Please enter maintenance description here.</div>
+       <div class="invalid-feedback">{{ form.incident_desc.errors | join(', ')
+         }}
+       </div>
+    </div>
+
     <div class="mb-3">
       <label for="{{form.incident_components.id}}"
         class="form-label">{{form.incident_components.label}}</label>
@@ -128,8 +147,10 @@
     function maintenanceCheck(elem) {
     if (elem.value == 0) {
         document.getElementById("maintenance_end").style.display = "block";
+        document.getElementById("maintenance_desc").style.display = "block";
     } else {
         document.getElementById("maintenance_end").style.display = "none";
+        document.getElementById("maintenance_desc").style.display = "none";
     }
 }
 </script>

--- a/app/web/templates/incident.html
+++ b/app/web/templates/incident.html
@@ -5,6 +5,14 @@
 
   <h4><i class="bi sd-{{ config['INCIDENT_IMPACTS'][incident.impact].key }}"></i>
     {{ incident.text }}</h4>
+  {% if incident.impact == 0 %}
+  <p class="indent">
+  {{ (incident.updates | selectattr('status', 'equalto', 'description') | first).text }}
+  {% block add_message %}
+    {% include 'message.html' ignore missing %}
+  {% endblock %}
+  </p>
+  {% endif %}
   <h6>Impact: {{ config['INCIDENT_IMPACTS'][incident.impact].string }}</h6>
   {% set regions = incident.get_attributes_by_key('region') %}
   <h6>Affected Region(s): {{
@@ -58,7 +66,7 @@
   <hr/>
 
   <div class="container text-left">
-  {% for update in incident.updates %}
+  {% for update in incident.updates | rejectattr('status', 'equalto', 'description') | list %}
     <div class="row">
         <div class="col-md-2">
             <h6>{{ update.status }}</h6>

--- a/app/web/templates/index.html
+++ b/app/web/templates/index.html
@@ -23,7 +23,7 @@
 {% endwith %}
 
 <div class="container">
-  {% set open_incidents = incidents.get_all_active() %}
+  {% set open_incidents = incidents.get_all_active() | rejectattr('impact', 'equalto', 0) | list %}
   {% if open_incidents | length == 0 %}
     <div class="alert alert-success" role="alert">
       All systems running
@@ -55,9 +55,9 @@
         </h6>
         <small class="text-secondary">Started: {{ incident.start_date.strftime('%Y-%m-%dT%H:%M') }}</small>
         <hr/>
-        {% if incident.updates | length != 0 %}
+        {% if incident.updates | rejectattr('status', 'equalto', 'description') | list | length != 0 %}
           <div class="container text-left">
-          {% set update = incident.updates[0] %}
+          {% set update = incident.updates | rejectattr('status', 'equalto', 'description') | list | first %}
             <div class="row">
                 <div class="col-md-2">
                     <h6>{{ update.status }}</h6>
@@ -119,6 +119,63 @@
        </div>
    {% endfor %}
  </div>
+</div>
+
+{% set open_maintenances = incidents.get_all_active() | selectattr('impact', 'equalto', 0) | list %}
+{% if open_maintenances | length > 0 %}
+<div class="container"><br/>
+    {% for incident in open_maintenances | sort(attribute='start_date', reverse = True) %}
+      {% set impact = config['INCIDENT_IMPACTS'][incident.impact] %}
+        <div class="alert alert-{{impact.key}}" role="alert">
+          <h4 class="alert-heading">
+              <a class="alert-link"
+                  href="incidents/{{incident.id}}"> {{ incident.text }}</a>
+        </h4>
+      <p class="indent">
+      {{ (incident.updates | selectattr('status', 'equalto', 'description') | first).text }}
+      {% block add_message %}
+        {% include 'message.html' ignore missing %}
+      {% endblock %}
+      </p>
+	<h6>Impact: {{ impact.string }}</h6>
+	{% set regions = incident.get_attributes_by_key('region') %}
+        <h6>Affected Region(s): {{
+            regions
+            | join(', ')
+            }}</h6>
+        <h6>Affected Service(s):
+            {% set comma = joiner() %}
+            {% for comp in incident.components -%}
+            {% with attrs = comp.get_attributes_as_dict() -%}
+            {{ comma() }}{{ comp.name }}
+            {%- if regions|length > 1 %}
+            ({{attrs['region']}})
+            {%- endif %}
+            {%- endwith %}
+            {%- endfor %}
+        </h6>
+        <small class="text-secondary">Started: {{ incident.start_date.strftime('%Y-%m-%dT%H:%M') }}</small>
+        <br/>
+        <small class="text-secondary">Planned end date: {{ incident.end_date.strftime('%Y-%m-%dT%H:%M') }}</small>
+        <hr/>
+        {% if incident.updates | rejectattr('status', 'equalto', 'description') | list | length != 0 %}
+          <div class="container text-left">
+          {% set update = incident.updates | rejectattr('status', 'equalto', 'description') | list | first %}
+            <div class="row">
+                <div class="col-md-2">
+                    <h6>{{ update.status }}</h6>
+                    <small class="text-secondary">Posted {{ update.timestamp.strftime('%Y-%m-%d %H:%M') }}</small>
+                </div>
+                <div class="col-md-10">
+                    {{ update.text }}
+                </div>
+                <hr/>
+            </div>
+          </div>
+        {% endif %}
+      </div>
+     {% endfor %}
+  {% endif %}
 </div>
 
 <div>


### PR DESCRIPTION
- when creating a maintenance, it is now possible to add a description up to 500 characters
- description is stored in incident_status table
- index page view adapted: display active maintenances below the components list