### PR TITLE
fix maintenance description

### DIFF
--- a/app/web/templates/incident.html
+++ b/app/web/templates/incident.html
@@ -7,7 +7,13 @@
     {{ incident.text }}</h4>
   {% if incident.impact == 0 %}
   <p class="indent">
-  {{ (incident.updates | selectattr('status', 'equalto', 'description') | first).text }}
+  {% set desc = incident.updates
+    | selectattr('status', 'equalto', 'description')
+    | first
+    | default(None) %}
+  {% if desc %}
+    {{ desc.text }}
+  {% endif %}
   {% block add_message %}
     {% include 'message.html' ignore missing %}
   {% endblock %}

--- a/app/web/templates/index.html
+++ b/app/web/templates/index.html
@@ -132,7 +132,13 @@
                   href="incidents/{{incident.id}}"> {{ incident.text }}</a>
         </h4>
       <p class="indent">
-      {{ (incident.updates | selectattr('status', 'equalto', 'description') | first).text }}
+      {% set desc = incident.updates
+        | selectattr('status', 'equalto', 'description')
+        | first
+        | default(None) %}
+      {% if desc %}
+        {{ desc.text }}
+      {% endif %}
       {% block add_message %}
         {% include 'message.html' ignore missing %}
       {% endblock %}


### PR DESCRIPTION
When a maintenance didn't have a description, it could lead to Internal Server Error. This fixes the issue.