### PR TITLE
months validation added

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -186,33 +186,34 @@ class Component(Base):
         sla_dict = {month: 1 for month in months}
 
         for month_start, outage_group in outages_dict_sorted.items():
-            minutes_in_month = prev_month_minutes
-            outages_minutes = 0
-            prev_month_minutes = 0
+            if month_start in months:
+                minutes_in_month = prev_month_minutes
+                outages_minutes = 0
+                prev_month_minutes = 0
 
-            if this_month_start.month == month_start.month:
-                minutes_in_month = (
-                    time_now - month_start
-                ).total_seconds() / 60
-            else:
-                next_month_start = month_start + relativedelta(months=1)
-                minutes_in_month = (
-                    next_month_start - month_start
-                ).total_seconds() / 60
+                if this_month_start.month == month_start.month:
+                    minutes_in_month = (
+                        time_now - month_start
+                    ).total_seconds() / 60
+                else:
+                    next_month_start = month_start + relativedelta(months=1)
+                    minutes_in_month = (
+                        next_month_start - month_start
+                    ).total_seconds() / 60
 
-            for outage in outage_group:
-                outage_start = outage.start_date
-                if outage_start < month_start:
-                    diff = month_start - outage_start
-                    prev_month_minutes += diff.total_seconds() / 60
-                    outage_start = month_start
+                for outage in outage_group:
+                    outage_start = outage.start_date
+                    if outage_start < month_start:
+                        diff = month_start - outage_start
+                        prev_month_minutes += diff.total_seconds() / 60
+                        outage_start = month_start
 
-                diff = outage.end_date - outage_start
-                outages_minutes += diff.total_seconds() / 60
+                    diff = outage.end_date - outage_start
+                    outages_minutes += diff.total_seconds() / 60
 
-            sla_dict[month_start] = (
-                minutes_in_month - outages_minutes
-            ) / minutes_in_month
+                sla_dict[month_start] = (
+                    minutes_in_month - outages_minutes
+                ) / minutes_in_month
 
         return sla_dict
 


### PR DESCRIPTION
Please look at the issue:
https://github.com/stackmon/status-dashboard/issues/113

The method returned all months from the outage_dict,
but needs only last 6 months from:
`months = [this_month_start + relativedelta(months=-mon)
                  for mon in range(6)]`

Changed:
`for month_start, outage_group in outages_dict_sorted.items():`
`    if month_start in months:`
added "if month_start in months:"


![image](https://github.com/stackmon/status-dashboard/assets/39965096/19a4f3f2-2af6-466e-9b5a-a55ffaed9b0d)


highlights:
before:
`218
Object Storage Service
7
{datetime.datetime(2024, 4, 1, 0, 0): 1, datetime.datetime(2024, 3, 1, 0, 0): 1, datetime.datetime(2024, 2, 1, 0, 0): 1, datetime.datetime(2024, 1, 1, 0, 0): 1, datetime.datetime(2023, 12, 1, 0, 0): 1, datetime.datetime(2023, 11, 1, 0, 0): 1, datetime.datetime(2023, 10, 1, 0, 0): 0.9998984468339307}`

after:
`218
Object Storage Service
6
{datetime.datetime(2024, 4, 1, 0, 0): 1, datetime.datetime(2024, 3, 1, 0, 0): 1, datetime.datetime(2024, 2, 1, 0, 0): 1, datetime.datetime(2024, 1, 1, 0, 0): 1, datetime.datetime(2023, 12, 1, 0, 0): 1, datetime.datetime(2023, 11, 1, 0, 0): 0.9984027777777778}`