### PR TITLE
Issue 123

### DIFF
--- a/app/datetime/__init__.py
+++ b/app/datetime/__init__.py
@@ -10,7 +10,8 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 #
-from datetime import datetime, timezone
+from datetime import datetime, timezone, timedelta
+from zoneinfo import ZoneInfo
 
 
 def datetime_utcnow():
@@ -22,9 +23,20 @@ def utc_from_timestamp(timestamp):
     # type: (float) -> datetime
     return datetime.fromtimestamp(timestamp, timezone.utc)
 
-def naive_timestamp(timestamp):
+def naive_from_timestamp(timestamp):
     return utc_from_timestamp(timestamp).replace(tzinfo=None)
-
 
 def naive_utcnow():
     return datetime_utcnow().replace(tzinfo=None)
+
+def naive_from_dttz(timeobject: datetime, timezone: str) -> datetime:
+    if timeobject is None:
+        raise ValueError("timeobject cannot be None")
+    if timezone is None:
+        raise ValueError("timezone cannot be None")
+    try:
+        tz = ZoneInfo(timezone)
+    except Exception as e:
+        raise ValueError(f"Invalid timezone: {timezone}") from e
+    date_new_tz = timeobject.replace(tzinfo=tz)
+    return naive_from_timestamp(date_new_tz.timestamp())

--- a/app/datetime/__init__.py
+++ b/app/datetime/__init__.py
@@ -10,7 +10,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 #
-from datetime import datetime, timezone, timedelta
+from datetime import datetime, timezone
 from zoneinfo import ZoneInfo
 
 
@@ -23,20 +23,26 @@ def utc_from_timestamp(timestamp):
     # type: (float) -> datetime
     return datetime.fromtimestamp(timestamp, timezone.utc)
 
+
 def naive_from_timestamp(timestamp):
     return utc_from_timestamp(timestamp).replace(tzinfo=None)
 
+
 def naive_utcnow():
     return datetime_utcnow().replace(tzinfo=None)
+
 
 def naive_from_dttz(timeobject: datetime, timezone: str) -> datetime:
     if timeobject is None:
         raise ValueError("timeobject cannot be None")
     if timezone is None:
         raise ValueError("timezone cannot be None")
+
     try:
         tz = ZoneInfo(timezone)
     except Exception as e:
         raise ValueError(f"Invalid timezone: {timezone}") from e
+
     date_new_tz = timeobject.replace(tzinfo=tz)
+
     return naive_from_timestamp(date_new_tz.timestamp())

--- a/app/datetime/__init__.py
+++ b/app/datetime/__init__.py
@@ -22,6 +22,9 @@ def utc_from_timestamp(timestamp):
     # type: (float) -> datetime
     return datetime.fromtimestamp(timestamp, timezone.utc)
 
+def naive_timestamp(timestamp):
+    return utc_from_timestamp(timestamp).replace(tzinfo=None)
+
 
 def naive_utcnow():
     return datetime_utcnow().replace(tzinfo=None)

--- a/app/default_settings.py
+++ b/app/default_settings.py
@@ -50,6 +50,7 @@ class DefaultConfiguration:
     MAINTENANCE_STATUSES = {
         "scheduled": "Maintenance scheduled",
         "in progress": "Maintenance is in progress",
+        "modified": "Maintenance time window has been modified",
         "completed": "Maintenance is successfully completed",
     }
 

--- a/app/default_settings.py
+++ b/app/default_settings.py
@@ -54,7 +54,6 @@ class DefaultConfiguration:
     }
 
     INCIDENT_STATUSES = {
-        "converted": "Incident Converted to maintenance",
         "analyzing": "Analyzing incident (problem not known yet)",
         "fixing": "Fixing incident (problem identified, working on fix)",
         "observing": "Observing fix (fix deployed, watching recovery)",
@@ -62,6 +61,6 @@ class DefaultConfiguration:
     }
 
     INCIDENT_ACTIONS = {
-        "reopened" : "Incident reopened (resolved incident has ben reopened)",
-        "changed" : "Incident changed: (resolved incident has been changed)",
+        "reopened": "Incident reopened (resolved incident has ben reopened)",
+        "changed": "Incident changed: (end date has been changed)",
     }

--- a/app/default_settings.py
+++ b/app/default_settings.py
@@ -59,3 +59,8 @@ class DefaultConfiguration:
         "observing": "Observing fix (fix deployed, watching recovery)",
         "resolved": "Incident Resolved (service is fully available. Done)",
     }
+
+    INCIDENT_ACTIONS = {
+        "reopened" : "Incident reopened (resolved incident has ben reopened)",
+        "changed" : "Incident changed: (resolved incident has been changed)",
+    }

--- a/app/default_settings.py
+++ b/app/default_settings.py
@@ -54,6 +54,7 @@ class DefaultConfiguration:
     }
 
     INCIDENT_STATUSES = {
+        "converted": "Incident Converted to maintenance",
         "analyzing": "Analyzing incident (problem not known yet)",
         "fixing": "Fixing incident (problem identified, working on fix)",
         "observing": "Observing fix (fix deployed, watching recovery)",

--- a/app/web/forms.py
+++ b/app/web/forms.py
@@ -55,7 +55,6 @@ class IncidentUpdateForm(FlaskForm):
         if field.data is None:
             if self.update_status.data in [
                 "resolved",
-                "completed",
                 "reopened"
             ]:
                 field.errors[:] = []
@@ -74,53 +73,43 @@ class IncidentUpdateForm(FlaskForm):
             upd_date_form = None
             raise validators.ValidationError("Update date cannot be empty")
 
+        # if self.update_status.data == "resolved":
+        #     if upd_date_form > naive_utcnow():
+        #         raise validators.ValidationError(
+        #             "End date cannot be in the future"
+        #         )
+        #     if upd_date_form < self._start_date:
+        #         raise validators.ValidationError(
+        #             "End date cannot be before the start date"
+        #         )
+        #     for timestamp in self._updates_ts:
+        #         if upd_date_form <= timestamp:
+        #             raise validators.ValidationError(
+        #                 "End date cannot be before any "
+        #                 "other status-update timestamp or equal"
+        #             )
+        # elif self.update_status.data == "changed":
+        #     if upd_date_form > naive_utcnow():
+        #         raise validators.ValidationError(
+        #             "End date cannot be in the future"
+        #         )
+        #     if upd_date_form < self._start_date:
+        #         raise validators.ValidationError(
+        #             "End date cannot be before the start date"
+        #         )
+        #     for timestamp in self._updates_ts:
+        #         if upd_date_form <= timestamp:
+        #             raise validators.ValidationError(
+        #                 "End date cannot be before any "
+        #                 "other status-update timestamp or equal"
+        #             )
         if self.update_status.data in [
-            "resolved",
-            "completed",
-            "reopened",
-        ]:
-            if upd_date_form > naive_utcnow():
-                raise validators.ValidationError(
-                    "End date cannot be in the future"
-                )
-            if upd_date_form < self._start_date:
-                raise validators.ValidationError(
-                    "End date cannot be before the start date"
-                )
-            if field.data is not None and field.data < self._start_date:
-                raise validators.ValidationError(
-                    "End date cannot be before the start date"
-                )
-            for timestamp in self._updates_ts:
-                if upd_date_form <= timestamp:
-                    raise validators.ValidationError(
-                        "End date cannot be before any "
-                        "other status-update timestamp or equal"
-                    )
-        elif self.update_status.data == "changed":
-            if upd_date_form > naive_utcnow():
-                raise validators.ValidationError(
-                    "End date cannot be in the future"
-                )
-            if upd_date_form < self._start_date:
-                raise validators.ValidationError(
-                    "End date cannot be before the start date"
-                )
-            if field.data < self._start_date:
-                raise validators.ValidationError(
-                    "End date cannot be before the start date"
-                )
-            for timestamp in self._updates_ts:
-                if upd_date_form <= timestamp:
-                    raise validators.ValidationError(
-                        "End date cannot be before any "
-                        "other status-update timestamp or equal"
-                    )
-        elif self.update_status.data in [
             "analyzing",
             "fixing",
             "observing",
-            "in progress"
+            "in progress",
+            "resolved",
+            "changed",
         ]:
             if upd_date_form > naive_utcnow():
                 raise validators.ValidationError(
@@ -136,16 +125,145 @@ class IncidentUpdateForm(FlaskForm):
                         "End date cannot be before any "
                         "other status-update timestamp or equal"
                     )
-        if self.update_status.data == "scheduled":
+
+
+class MaintenanceUpdateForm(FlaskForm):
+    update_title = StringField(
+        "Incident Title",
+        validators=[
+            validators.DataRequired(),
+            validators.Length(min=8, max=200),
+        ],
+    )
+    update_text = TextAreaField(
+        "Update Message",
+        validators=[
+            validators.DataRequired(),
+            validators.Length(min=10, max=200),
+        ],
+    )
+    update_impact = SelectField("Incident Impact")
+    update_status = SelectField("Update Status")
+    start_date = DateTimeField("Start date", format='%Y-%m-%dT%H:%M')
+    end_date = DateTimeField("End date", format='%Y-%m-%dT%H:%M')
+    update_date = DateTimeField("Next Update by", format='%Y-%m-%dT%H:%M')
+    timezone = StringField("Timezone", validators=[validators.DataRequired()])
+    submit = SubmitField("Submit")
+
+    def __init__(self, _start_date, _end_date, _updates_ts, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._start_date = _start_date
+        self._end_date = _end_date
+        self._updates_ts = _updates_ts
+
+    def validate_incident_start(self, field):
+        start_date_form = naive_from_dttz(
+            self.start_date.data,
+            self.timezone.data,
+        )
+        if (
+            self.incident_impact.data != "0"
+            and start_date_form > naive_utcnow()
+        ):
+            raise validators.ValidationError(
+                "Start date of incident cannot be in the future"
+            )
+
+    def validate_update_date(self, field):
+        if field.data is None:
+            if self.update_status.data in ["modified", "completed"]:
+                field.errors[:] = []
+                raise validators.StopValidation()
+
+        if field.data is not None:
+            upd_date_form = naive_from_dttz(
+                self.update_date.data,
+                self.timezone.data,
+            )
+        else:
+            upd_date_form = None
+            raise validators.ValidationError("Update date cannot be empty")
+
+        if self.update_status.data in [
+            "scheduled",
+            "in progress",
+        ]:
+            if upd_date_form > naive_utcnow():
+                raise validators.ValidationError(
+                    "Update date cannot be in the future"
+                )
             if upd_date_form < self._start_date:
                 raise validators.ValidationError(
-                    "Scheduled date cannot be before the start date"
+                    "End date cannot be before the start date"
                 )
             for timestamp in self._updates_ts:
                 if upd_date_form <= timestamp:
                     raise validators.ValidationError(
-                        "Scheduled date cannot be before any "
+                        "End date cannot be before any "
                         "other status-update timestamp or equal"
+                    )
+            if upd_date_form > self._end_date:
+                raise validators.ValidationError(
+                    "The update date cannot be later than the end date"
+                )
+
+    def validate_start_date(self, field):
+        if self.update_status.data != "modified":
+            field.errors[:] = []
+            raise validators.StopValidation()
+        else:
+            if field.data is None:
+                raise validators.ValidationError(
+                    "Start date cannot be empty"
+                )
+
+            start_date_form = naive_from_dttz(
+                field.data,
+                self.timezone.data,
+            )
+
+            if self.end_date.data:
+                end_date_form = naive_from_dttz(
+                    self.end_date.data,
+                    self.timezone.data,
+                )
+                if start_date_form > end_date_form:
+                    raise validators.ValidationError(
+                        "Start date cannot be later end date"
+                    )
+            for timestamp in self._updates_ts:
+                if start_date_form > timestamp:
+                    raise validators.ValidationError(
+                        "Start date cannot be later any update timestamp"
+                    )
+
+    def validate_end_date(self, field):
+        if self.update_status.data != "modified":
+            field.errors[:] = []
+            raise validators.StopValidation()
+        else:
+            if field.data is None:
+                raise validators.ValidationError(
+                    "End date cannot be empty"
+                )
+
+            end_date_form = naive_from_dttz(
+                field.data,
+                self.timezone.data,
+            )
+            if self.start_date.data:
+                start_date_form = naive_from_dttz(
+                    self.start_date.data,
+                    self.timezone.data,
+                )
+                if end_date_form < start_date_form:
+                    raise validators.ValidationError(
+                        "End date cannot be before start date"
+                    )
+            for timestamp in self._updates_ts:
+                if end_date_form < timestamp:
+                    raise validators.ValidationError(
+                        "End date cannot be before any update timestamp"
                     )
 
 

--- a/app/web/forms.py
+++ b/app/web/forms.py
@@ -10,6 +10,8 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 #
+from app.datetime import naive_from_dttz
+from app.datetime import naive_utcnow
 
 from flask_wtf import FlaskForm
 
@@ -19,9 +21,6 @@ from wtforms import StringField
 from wtforms import SubmitField
 from wtforms import TextAreaField
 from wtforms import validators
-
-from app.datetime import naive_utcnow
-from app.datetime import naive_from_dttz
 
 
 class IncidentUpdateForm(FlaskForm):
@@ -43,7 +42,6 @@ class IncidentUpdateForm(FlaskForm):
     update_status = SelectField("Update Status")
     update_date = DateTimeField("Next Update by", format='%Y-%m-%dT%H:%M')
     timezone = StringField("Timezone", validators=[validators.DataRequired()])
-    
     submit = SubmitField("Submit")
 
     def __init__(self, _start_date, _updates_ts, *args, **kwargs):
@@ -53,63 +51,102 @@ class IncidentUpdateForm(FlaskForm):
         self._updates_ts = _updates_ts
 
     def validate_update_date(self, field):
-        form_timestamp = naive_from_dttz(
-            self.update_date.data,
-            self.timezone.data,
-        ) if self.update_date.data else naive_utcnow()
-        if (
-            self.update_status.data not in [
+
+        if field.data is None:
+            if self.update_status.data in [
                 "resolved",
                 "completed",
-                "reopened",
-            ]
-            and field.data is None
-        ):
-            raise validators.ValidationError(
-                "Next update field is mandatory unless "
-                "incident is resolved"
-            )
-        elif self.update_status.data == "converted":
-            # Ensure update_date is not before the start date
-            if form_timestamp < self._start_date:
+                "reopened"
+            ]:
+                field.errors[:] = []
+                raise validators.StopValidation()
+            elif self.update_status.data == "changed":
                 raise validators.ValidationError(
-                    "End date cannot be before the start date"
+                    "New end date field cannot be empty"
                 )
-            for timestamp in self._updates_ts:
-                if form_timestamp < timestamp:
-                    raise validators.ValidationError(
-                        "End date cannot be before any other "
-                        "status-update timestamp"
-                    )
-        elif self.update_status.data == "changed":
-            # Ensure update_date is not in the future
-            if form_timestamp > naive_utcnow():
+
+        if field.data is not None:
+            upd_date_form = naive_from_dttz(
+                self.update_date.data,
+                self.timezone.data,
+            )
+        else:
+            upd_date_form = None
+            raise validators.ValidationError("Update date cannot be empty")
+
+        if self.update_status.data in [
+            "resolved",
+            "completed",
+            "reopened",
+        ]:
+            if upd_date_form > naive_utcnow():
                 raise validators.ValidationError(
                     "End date cannot be in the future"
                 )
-            # Ensure update_date is not before the start date
-            if form_timestamp < self._start_date:
+            if upd_date_form < self._start_date:
+                raise validators.ValidationError(
+                    "End date cannot be before the start date"
+                )
+            if field.data is not None and field.data < self._start_date:
                 raise validators.ValidationError(
                     "End date cannot be before the start date"
                 )
             for timestamp in self._updates_ts:
-                if form_timestamp < timestamp:
+                if upd_date_form <= timestamp:
                     raise validators.ValidationError(
-                        "End date cannot be before any other "
-                        "status-update timestamp"
+                        "End date cannot be before any "
+                        "other status-update timestamp or equal"
                     )
-        elif (
-            self.update_status.data in [
-                "resolved",
-                "completed",
-                "reopened",
-            ]
-            and field.data is None
-        ):
-            # Making field optional requres dropping "Not a valid datetime
-            # value." error as well
-            field.errors[:] = []
-            raise validators.StopValidation()
+        elif self.update_status.data == "changed":
+            if upd_date_form > naive_utcnow():
+                raise validators.ValidationError(
+                    "End date cannot be in the future"
+                )
+            if upd_date_form < self._start_date:
+                raise validators.ValidationError(
+                    "End date cannot be before the start date"
+                )
+            if field.data < self._start_date:
+                raise validators.ValidationError(
+                    "End date cannot be before the start date"
+                )
+            for timestamp in self._updates_ts:
+                if upd_date_form <= timestamp:
+                    raise validators.ValidationError(
+                        "End date cannot be before any "
+                        "other status-update timestamp or equal"
+                    )
+        elif self.update_status.data in [
+            "analyzing",
+            "fixing",
+            "observing",
+            "in progress"
+        ]:
+            if upd_date_form > naive_utcnow():
+                raise validators.ValidationError(
+                    "Update date cannot be in the future"
+                )
+            if upd_date_form < self._start_date:
+                raise validators.ValidationError(
+                    "End date cannot be before the start date"
+                )
+            for timestamp in self._updates_ts:
+                if upd_date_form <= timestamp:
+                    raise validators.ValidationError(
+                        "End date cannot be before any "
+                        "other status-update timestamp or equal"
+                    )
+        if self.update_status.data == "scheduled":
+            if upd_date_form < self._start_date:
+                raise validators.ValidationError(
+                    "Scheduled date cannot be before the start date"
+                )
+            for timestamp in self._updates_ts:
+                if upd_date_form <= timestamp:
+                    raise validators.ValidationError(
+                        "Scheduled date cannot be before any "
+                        "other status-update timestamp or equal"
+                    )
 
 
 class IncidentForm(FlaskForm):
@@ -140,15 +177,14 @@ class IncidentForm(FlaskForm):
 
     submit = SubmitField("Submit")
 
-
     def validate_incident_start(self, field):
-        form_timestamp = naive_from_dttz(
-            self.incident_start.data, 
+        start_date_form = naive_from_dttz(
+            self.incident_start.data,
             self.timezone.data,
         )
         if (
             self.incident_impact.data != "0"
-            and form_timestamp > naive_utcnow()
+            and start_date_form > naive_utcnow()
         ):
             raise validators.ValidationError(
                 "Start date of incident cannot be in the future"
@@ -168,20 +204,5 @@ class IncidentForm(FlaskForm):
         ):
             # Making field optional requres dropping "Not a valid datetime
             # value." error as well
-            field.errors[:] = []
-            raise validators.StopValidation()
-
-    def validate_incident_end(self, field):
-        if (
-            self.incident_impact.data == "0"
-            and field.data is None
-        ):
-            raise validators.ValidationError(
-                "Expected end date field is mandatory for maintenance"
-            )
-        elif (
-            self.incident_impact.data != "0"
-            and field.data is None
-        ):
             field.errors[:] = []
             raise validators.StopValidation()

--- a/app/web/forms.py
+++ b/app/web/forms.py
@@ -62,6 +62,46 @@ class IncidentUpdateForm(FlaskForm):
             field.errors[:] = []
             raise validators.StopValidation()
 
+class IncidentChangeForm(FlaskForm):
+    update_title = StringField(
+        "Incident Title",
+        validators=[
+            validators.DataRequired(),
+            validators.Length(min=8, max=200),
+        ],
+    )
+    update_text = TextAreaField(
+        "Update Message",
+        validators=[
+            validators.DataRequired(),
+            validators.Length(min=10, max=200),
+        ],
+    )
+    update_impact = SelectField("Incident Impact")
+    update_status = SelectField("Change Action")
+    next_update = DateTimeField("New end date", format='%Y-%m-%dT%H:%M')
+    submit = SubmitField("Submit")
+
+    def __init__(self, incident_id, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.incident_id = incident_id
+
+    def validate_change(self, field):
+        if (
+            self.update_status.data not in ["resolved", "completed"]
+            and field.data is None
+        ):
+            raise validators.ValidationError(
+                "Next update field is mandatory unless " "incident is resolved"
+            )
+        elif (
+            self.update_status.data in ["resolved", "completed"]
+            and field.data is None
+        ):
+            # Making field optional requres dropping "Not a valid datetime
+            # value." error as well
+            field.errors[:] = []
+            raise validators.StopValidation()
 
 class IncidentForm(FlaskForm):
     incident_text = StringField(

--- a/app/web/routes.py
+++ b/app/web/routes.py
@@ -178,8 +178,12 @@ def incident(incident_id):
         abort(404)
     form = None
     start_date = incident.start_date
+    updates = incident.updates
+    updates_ts = []
+    for u in updates:
+        updates_ts.append(u.timestamp)
     if "user" in session:
-        form = IncidentUpdateForm(start_date)
+        form = IncidentUpdateForm(start_date, updates_ts)
         form.update_impact.choices = [
             (v.value, v.string)
             for (_, v) in current_app.config["INCIDENT_IMPACTS"].items()
@@ -224,6 +228,7 @@ def incident(incident_id):
             incident.impact = new_impact
             incident.system = False
             db.session.commit()
+            return redirect("/history")
 
     return render_template(
         "incident.html", title="Incident", incident=incident, form=form

--- a/app/web/routes.py
+++ b/app/web/routes.py
@@ -133,6 +133,7 @@ def form_submission(form, incident):
         current_app.logger.debug(
             f"{incident} modified by {get_user_string(session['user'])}"
         )
+        redirect_path = "/"
 
     incident.text = form.update_title.data
     incident.impact = new_impact
@@ -266,7 +267,13 @@ def incident(incident_id):
     else:
         end_date = None
     updates = incident.updates
-    updates_ts = [u.timestamp for u in updates if u.status != 'description']
+    updates_ts = [
+        u.timestamp for u in updates if u.status not in [
+            "resolved",
+            "description",
+            "changed",
+        ]
+    ]
     now = naive_utcnow()
 
     if "user" in session:

--- a/app/web/templates/create_incident.html
+++ b/app/web/templates/create_incident.html
@@ -109,20 +109,12 @@
              id="{{form.incident_start.id}}"
              name="{{form.incident_start.name}}"
              value="{{form.incident_start.data}}"
-             aria-describedby="incidentStartHelp"
-             onchange="startToUTC(this.value)"/>
+             aria-describedby="incidentStartHelp"/>
       <div id="incidentStartHelp" class="form-text">
         Select the incident start time.
       </div>
       <div class="invalid-feedback">{{form.incident_start.errors | join(', ')
         }}</div>
-    </div>
-
-    <div>
-      <input type="hidden"
-             id="{{form.incident_start_utc.id}}"
-             name="{{form.incident_start_utc.name}}"
-             value="{{form.incident_start_utc.data}}"/>
     </div>
 
     <div id="maintenance_end" class="mb-3"
@@ -138,8 +130,7 @@
              id="{{form.incident_end.id}}"
              name="{{form.incident_end.name}}"
              value="{{form.incident_end.data}}"
-             aria-describedby="incidentEndHelp"
-             onchange="endToUTC(this.value)"/>
+             aria-describedby="incidentEndHelp"/>
       <div id="incidentEndHelp" class="form-text">
         Select the maintenance expected end time.
       </div>
@@ -155,28 +146,17 @@
       </div>
 
       <div>
-      <input type="hidden"
-             id="{{form.incident_end_utc.id}}"
-             name="{{form.incident_end_utc.name}}"
-             value="{{form.incident_end_utc.data}}"/>
+      <input type="hidden" 
+             id="timezone"
+             name="timezone">
       </div>
-
+    
     <button type="submit" class="btn btn-primary">Submit</button>
     </form>
-
+    
 </div>
 
 <script>
-    function startToUTC(val) {
-      var start_local = new Date(val);
-      document.getElementById("{{form.incident_start_utc.id}}").value = start_local.toISOString().split('.')[0].replace('T', ' ');
-    }
-
-    function endToUTC(val) {
-      var end_local = new Date(val);
-      document.getElementById("{{form.incident_end_utc.id}}").value = end_local.toISOString().split('.')[0].replace('T', ' ');
-    }
-
     function maintenanceCheck(elem) {
     if (elem.value == 0) {
         document.getElementById("maintenance_end").style.display = "block";
@@ -198,4 +178,16 @@
   };
 </script>
 
+<script>
+  // Function to set the timezone
+  document.addEventListener('DOMContentLoaded', function() {
+    var timezoneField = document.getElementById('timezone');
+    var timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    if (timezone) {
+      timezoneField.value = timezone;
+    } else {
+          timezoneField.value = 'UTC';
+    }
+  });
+</script>
 {% endblock %}

--- a/app/web/templates/incident.html
+++ b/app/web/templates/incident.html
@@ -224,10 +224,14 @@
 </div>
 <script>
   // Function to set the timezone
-  document.addEventListener('DOMContentLoaded', (event) => {
+  document.addEventListener('DOMContentLoaded', function() {
     var timezoneField = document.getElementById('timezone');
     var timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
-    timezoneField.value = timezone;
+    if (timezone) {
+      timezoneField.value = timezone;
+    } else {
+          timezoneField.value = 'UTC';
+    }
   });
 </script>
 {% endblock %}

--- a/app/web/templates/incident.html
+++ b/app/web/templates/incident.html
@@ -163,60 +163,114 @@
 
       </div>
 
-      <div class="mb-3">
-        <label for="{{form.update_status.id}}" class="form-label">{{form.update_status.label}}</label>
-        <select
-            class="form-select form-select-sm mb-3
-                   {% if form.update_status.errors %}is-invalid{% endif %}
-                    "
-            aria-label=".form-select-sm"
-            id="{{form.update_status.id}}"
-            name="{{form.update_status.name}}">
-          <option>Choose...</option>
-          {% for (k, v) in form.update_status.choices %}
-          <option
-          {% if form.update_status.data and k|string in form.update_status.data %} selected
-          {% endif %}
-          value="{{k}}">{{v}}</option>
-          {% endfor %}
-        </select>
 
-        <div id="updateStatusHelp" class="form-text">Please enter update status
-        here.</div>
-        {% if form.update_status.errors %}
-        <div class="invalid-feedback">
-          <ul class="errors">
-            {% for error in form.update_status.errors %}
-               <li>{{ error }}</li>
+      {% if incident.end_date and incident.impact != 0 %}
+        {# Render a different form for incident closure #}
+        <div class="mb-3">
+          <label for="{{form.update_status.id}}" class="form-label">{{form.update_status.label}}</label>
+          <select
+              class="form-select form-select-sm mb-3
+                     {% if form.update_status.errors %}is-invalid{% endif %}
+                      "
+              aria-label=".form-select-sm"
+              id="{{form.update_status.id}}"
+              name="{{form.update_status.name}}">
+            <option>Choose...</option>
+            {% for (k, v) in form.update_status.choices %}
+            <option
+            {% if form.update_status.data and k|string in form.update_status.data %} selected
+            {% endif %}
+            value="{{k}}">{{v}}</option>
             {% endfor %}
-          </ul>
+          </select>
+          <div id="chooseActionHelp" class="form-text">Please choose an action 
+          here.</div>
+          {% if form.update_status.errors %}
+          <div class="invalid-feedback">
+            <ul class="errors">
+              {% for error in form.update_status.errors %}
+                 <li>{{ error }}</li>
+              {% endfor %}
+            </ul>
+          </div>
+          {% endif %}
         </div>
-        {% endif %}
-
-      </div>
-
-      <div class="mb-3">
-        <label for="{{form.next_update.id}}" class="form-label">{{form.next_update.label}}</label>
-        <input class="form-control
-                      {% if form.next_update.errors %}is-invalid{% endif %}"
-              type="datetime-local"
-              id="{{form.next_update.id}}"
-              name="{{form.next_update.name}}"
-              value="{{form.next_update.data}}"
-              aria-describedby="nextUpdateHelp"/>
-        <div id="nextUpdateHelp" class="form-text">
-          Please provide the time for the next expected update.</div>
-        {% if form.next_update.errors %}
-        <div class="invalid-feedback">
-          <ul class="errors">
-          {% for error in form.next_update.errors %}
-            <li>{{ error }}</li>
-          {% endfor %}
-          </ul>
+        <div class="mb-3">
+          <label for="{{form.next_update.id}}" class="form-label">{{form.next_update.label}}</label>
+          <input class="form-control
+                        {% if form.next_update.errors %}is-invalid{% endif %}"
+                type="datetime-local"
+                id="{{form.next_update.id}}"
+                name="{{form.next_update.name}}"
+                value="{{form.next_update.data}}"
+                aria-describedby="nextUpdateHelp"/>
+          <div id="nextUpdateHelp" class="form-text">
+            Please provide the time for the next expected update.</div>
+          {% if form.next_update.errors %}
+          <div class="invalid-feedback">
+            <ul class="errors">
+            {% for error in form.next_update.errors %}
+              <li>{{ error }}</li>
+            {% endfor %}
+            </ul>
+          </div>
+          {% endif %}
         </div>
-        {% endif %}
-      </div>
 
+      {% else %}
+      {# Render the default update form #}
+        <div class="mb-3">
+          <label for="{{form.update_status.id}}" class="form-label">{{form.update_status.label}}</label>
+          <select
+              class="form-select form-select-sm mb-3
+                     {% if form.update_status.errors %}is-invalid{% endif %}
+                      "
+              aria-label=".form-select-sm"
+              id="{{form.update_status.id}}"
+              name="{{form.update_status.name}}">
+            <option>Choose...</option>
+            {% for (k, v) in form.update_status.choices %}
+            <option
+            {% if form.update_status.data and k|string in form.update_status.data %} selected
+            {% endif %}
+            value="{{k}}">{{v}}</option>
+            {% endfor %}
+          </select>
+          <div id="updateStatusHelp" class="form-text">Please enter update status
+          here.</div>
+          {% if form.update_status.errors %}
+          <div class="invalid-feedback">
+            <ul class="errors">
+              {% for error in form.update_status.errors %}
+                 <li>{{ error }}</li>
+              {% endfor %}
+            </ul>
+          </div>
+          {% endif %}
+        </div>
+
+        <div class="mb-3">
+          <label for="{{form.next_update.id}}" class="form-label">{{form.next_update.label}}</label>
+          <input class="form-control
+                        {% if form.next_update.errors %}is-invalid{% endif %}"
+                type="datetime-local"
+                id="{{form.next_update.id}}"
+                name="{{form.next_update.name}}"
+                value="{{form.next_update.data}}"
+                aria-describedby="nextUpdateHelp"/>
+          <div id="nextUpdateHelp" class="form-text">
+            Please provide the time for the next expected update.</div>
+          {% if form.next_update.errors %}
+          <div class="invalid-feedback">
+            <ul class="errors">
+            {% for error in form.next_update.errors %}
+              <li>{{ error }}</li>
+            {% endfor %}
+            </ul>
+          </div>
+          {% endif %}
+        </div>
+      {% endif %}
       <button type="submit" class="btn btn-primary">Submit</button>
 
       </form>

--- a/app/web/templates/incident.html
+++ b/app/web/templates/incident.html
@@ -170,7 +170,7 @@
       <div class="mb-3">
         <label for="{{form.update_status.id}}" class="form-label">{{form.update_status.label}}</label>
         <select
-            onchange="updateDateLabel(this);"
+            onchange="updateDateLabel(this); updateMaintenanceFields(this);"
             class="form-select form-select-sm mb-3
                    {% if form.update_status.errors %}is-invalid{% endif %}"
             aria-label=".form-select-sm"
@@ -216,6 +216,50 @@
         </div>
         {% endif %}
       </div>
+      {% if form.start_date is defined %}
+        <div class="mb-3" id="maintenanceStartDiv" style="display: none;">
+          <label for="{{form.start_date.id}}" class="form-label" id="maintenanceStartLabel">{{form.start_date.label}}</label>
+          <input class="form-control {{ ' is-invalid' if
+                     form.start_date.errors
+                            | length > 0 else '' }}"
+                 type="datetime-local"
+                 id="{{form.start_date.id}}"
+                 name="{{form.start_date.name}}"
+                 value="{{form.start_date.data}}"
+                 aria-describedby="incidentStartHelp"/>
+          <div id="incidentStartHelp" class="form-text">
+            Select the incident start time.
+          </div>
+          <div class="invalid-feedback">{{form.start_date.errors | join(', ')
+            }}</div>
+        </div>
+      {% endif %}
+      {% if form.end_date is defined %}
+        <div class="mb-3" id="maintenanceEndDiv" style="display: none;">
+          <label for="{{form.end_date.id}}" class="form-label" id="maintenanceEndLabel">{{form.end_date.label}}</label>
+          <input class="form-control
+                          {% if form.end_date.errors %}is-invalid{% endif %}"
+                 type="datetime-local"
+                 id="{{form.end_date.id}}"
+                 name="{{form.end_date.name}}"
+                 value="{{form.end_date.data}}"
+                 aria-describedby="incidentEndHelp"/>
+          <div id="incidentEndHelp" class="form-text">
+            Select the maintenance expected end time.
+          </div>
+          {% if form.end_date.errors %}
+            <div class="invalid-feedback">
+              <ul class="errors">
+              {% for error in form.end_date.errors %}
+                <li>{{ error }}</li>
+              {% endfor %}
+              </ul>
+            </div>
+          {% endif %}
+        </div>
+      {% endif %}
+      
+
       <input type="hidden" id="timezone" name="timezone">
       <button type="submit" class="btn btn-primary">Submit</button>
 
@@ -235,32 +279,50 @@
     } else {
       timezoneField.value = 'UTC';
     }
-    updateDateLabel(); // Update the date label when the page loads
+    updateDateLabel();
+    updateMaintenanceFields();
   });
 
-  // Function to update the date label based on the selected status
   function updateDateLabel(selectElement) {
     var selectedValue = selectElement.value;
     var updateDateLabel = document.getElementById('updateDateLabel');
     var updateDateDiv = document.getElementById('updateDateDiv');
+
     switch (selectedValue) {
       case 'resolved':
       case 'completed':
         updateDateLabel.innerText = 'End Date:';
+        updateDateDiv.style.display = 'block';
         break;
       case 'reopened':
-        updateDateDiv.style.display = 'none'; // Hide date input
+        updateDateDiv.style.display = 'none';
         break;
       case 'changed':
-        updateDateDiv.style.display = 'Block'; // Show date input
+        updateDateDiv.style.display = 'block';
         updateDateLabel.innerText = 'End Date:';
         break;
-      case 'converted':
-        updateDateLabel.innerText = 'Planned maintenance End date:';
+      case 'modified':
+        updateDateDiv.style.display = 'none';
         break;
       default:
         updateDateLabel.innerText = 'Next Update by:';
+        updateDateDiv.style.display = 'block';
         break;
+    }
+  }
+
+  function updateMaintenanceFields(selectElement) {
+    var selectedValue = selectElement.value;
+    var maintenanceStartDiv = document.getElementById('maintenanceStartDiv');
+    var maintenanceEndDiv = document.getElementById('maintenanceEndDiv');
+    var incidentImpact = {{ incident.impact }};
+
+    if (selectedValue === 'modified' && incidentImpact == 0) {
+      maintenanceStartDiv.style.display = 'block';
+      maintenanceEndDiv.style.display = 'block';
+    } else {
+      maintenanceStartDiv.style.display = 'none';
+      maintenanceEndDiv.style.display = 'none';
     }
   }
 </script>

--- a/app/web/templates/incident.html
+++ b/app/web/templates/incident.html
@@ -160,7 +160,6 @@
           </ul>
         </div>
         {% endif %}
-
       </div>
 
       {# Render the default update form #}

--- a/app/web/templates/incident.html
+++ b/app/web/templates/incident.html
@@ -60,7 +60,11 @@
 {% if incident.impact == 0 %}
   <small>
     <b>Start date:</b> {{ incident.start_date.strftime('%Y-%m-%d %H:%M') }}&nbsp;UTC<br/>
-    <b>Planned end date:</b> {{ incident.end_date.strftime('%Y-%m-%d %H:%M') | default('no') }}&nbsp;UTC
+    {% if now <= incident.end_date %}
+      <b>Planned end date:</b> {{ incident.end_date.strftime('%Y-%m-%d %H:%M') | default('no') }}&nbsp;UTC
+    {% else %}
+      <b>End date:</b> {{ incident.end_date.strftime('%Y-%m-%d %H:%M') | default('no') }}&nbsp;UTC
+    {% endif %}
   </small>
 {% else %}
   <small>Incident began at
@@ -166,9 +170,9 @@
       <div class="mb-3">
         <label for="{{form.update_status.id}}" class="form-label">{{form.update_status.label}}</label>
         <select
+            onchange="updateDateLabel(this);"
             class="form-select form-select-sm mb-3
-                   {% if form.update_status.errors %}is-invalid{% endif %}
-                    "
+                   {% if form.update_status.errors %}is-invalid{% endif %}"
             aria-label=".form-select-sm"
             id="{{form.update_status.id}}"
             name="{{form.update_status.name}}">
@@ -180,8 +184,7 @@
           value="{{k}}">{{v}}</option>
           {% endfor %}
         </select>
-        <div id="updateStatusHelp" class="form-text">Please enter update status
-        here.</div>
+        <div id="updateStatusHelp" class="form-text">Please enter update status here.</div>
         {% if form.update_status.errors %}
         <div class="invalid-feedback">
           <ul class="errors">
@@ -192,8 +195,8 @@
         </div>
         {% endif %}
       </div>
-      <div class="mb-3">
-        <label for="{{form.update_date.id}}" class="form-label">{{form.update_date.label}}</label>
+      <div class="mb-3" id="updateDateDiv">
+        <label for="{{form.update_date.id}}" class="form-label" id="updateDateLabel">{{form.update_date.label}}</label>
         <input class="form-control
                       {% if form.update_date.errors %}is-invalid{% endif %}"
               type="datetime-local"
@@ -230,8 +233,35 @@
     if (timezone) {
       timezoneField.value = timezone;
     } else {
-          timezoneField.value = 'UTC';
+      timezoneField.value = 'UTC';
     }
+    updateDateLabel(); // Update the date label when the page loads
   });
+
+  // Function to update the date label based on the selected status
+  function updateDateLabel(selectElement) {
+    var selectedValue = selectElement.value;
+    var updateDateLabel = document.getElementById('updateDateLabel');
+    var updateDateDiv = document.getElementById('updateDateDiv');
+    switch (selectedValue) {
+      case 'resolved':
+      case 'completed':
+        updateDateLabel.innerText = 'End Date:';
+        break;
+      case 'reopened':
+        updateDateDiv.style.display = 'none'; // Hide date input
+        break;
+      case 'changed':
+        updateDateDiv.style.display = 'Block'; // Show date input
+        updateDateLabel.innerText = 'End Date:';
+        break;
+      case 'converted':
+        updateDateLabel.innerText = 'Planned maintenance End date:';
+        break;
+      default:
+        updateDateLabel.innerText = 'Next Update by:';
+        break;
+    }
+  }
 </script>
 {% endblock %}

--- a/app/web/templates/incident.html
+++ b/app/web/templates/incident.html
@@ -193,31 +193,41 @@
         {% endif %}
       </div>
       <div class="mb-3">
-        <label for="{{form.date_update.id}}" class="form-label">{{form.date_update.label}}</label>
+        <label for="{{form.update_date.id}}" class="form-label">{{form.update_date.label}}</label>
         <input class="form-control
-                      {% if form.date_update.errors %}is-invalid{% endif %}"
+                      {% if form.update_date.errors %}is-invalid{% endif %}"
               type="datetime-local"
-              id="{{form.date_update.id}}"
-              name="{{form.date_update.name}}"
-              value="{{form.date_update.data}}"
+              id="{{form.update_date.id}}"
+              name="{{form.update_date.name}}"
+              value="{{form.update_date.data}}"
               aria-describedby="nextUpdateHelp"/>
         <div id="nextUpdateHelp" class="form-text">
           Please provide the time for the next expected update.</div>
-        {% if form.date_update.errors %}
+        {% if form.update_date.errors %}
         <div class="invalid-feedback">
           <ul class="errors">
-          {% for error in form.date_update.errors %}
+          {% for error in form.update_date.errors %}
             <li>{{ error }}</li>
           {% endfor %}
           </ul>
         </div>
         {% endif %}
       </div>
+      <input type="hidden" id="timezone" name="timezone">
       <button type="submit" class="btn btn-primary">Submit</button>
 
       </form>
     </div>
+
   {% endif %}
 
 </div>
+<script>
+  // Function to set the timezone
+  document.addEventListener('DOMContentLoaded', (event) => {
+    var timezoneField = document.getElementById('timezone');
+    var timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    timezoneField.value = timezone;
+  });
+</script>
 {% endblock %}

--- a/app/web/templates/incident.html
+++ b/app/web/templates/incident.html
@@ -163,114 +163,57 @@
 
       </div>
 
-
-      {% if incident.end_date and incident.impact != 0 %}
-        {# Render a different form for incident closure #}
-        <div class="mb-3">
-          <label for="{{form.update_status.id}}" class="form-label">{{form.update_status.label}}</label>
-          <select
-              class="form-select form-select-sm mb-3
-                     {% if form.update_status.errors %}is-invalid{% endif %}
-                      "
-              aria-label=".form-select-sm"
-              id="{{form.update_status.id}}"
-              name="{{form.update_status.name}}">
-            <option>Choose...</option>
-            {% for (k, v) in form.update_status.choices %}
-            <option
-            {% if form.update_status.data and k|string in form.update_status.data %} selected
-            {% endif %}
-            value="{{k}}">{{v}}</option>
-            {% endfor %}
-          </select>
-          <div id="chooseActionHelp" class="form-text">Please choose an action 
-          here.</div>
-          {% if form.update_status.errors %}
-          <div class="invalid-feedback">
-            <ul class="errors">
-              {% for error in form.update_status.errors %}
-                 <li>{{ error }}</li>
-              {% endfor %}
-            </ul>
-          </div>
-          {% endif %}
-        </div>
-        <div class="mb-3">
-          <label for="{{form.next_update.id}}" class="form-label">{{form.next_update.label}}</label>
-          <input class="form-control
-                        {% if form.next_update.errors %}is-invalid{% endif %}"
-                type="datetime-local"
-                id="{{form.next_update.id}}"
-                name="{{form.next_update.name}}"
-                value="{{form.next_update.data}}"
-                aria-describedby="nextUpdateHelp"/>
-          <div id="nextUpdateHelp" class="form-text">
-            Please provide the time for the next expected update.</div>
-          {% if form.next_update.errors %}
-          <div class="invalid-feedback">
-            <ul class="errors">
-            {% for error in form.next_update.errors %}
-              <li>{{ error }}</li>
-            {% endfor %}
-            </ul>
-          </div>
-          {% endif %}
-        </div>
-
-      {% else %}
       {# Render the default update form #}
-        <div class="mb-3">
-          <label for="{{form.update_status.id}}" class="form-label">{{form.update_status.label}}</label>
-          <select
-              class="form-select form-select-sm mb-3
-                     {% if form.update_status.errors %}is-invalid{% endif %}
-                      "
-              aria-label=".form-select-sm"
-              id="{{form.update_status.id}}"
-              name="{{form.update_status.name}}">
-            <option>Choose...</option>
-            {% for (k, v) in form.update_status.choices %}
-            <option
-            {% if form.update_status.data and k|string in form.update_status.data %} selected
-            {% endif %}
-            value="{{k}}">{{v}}</option>
-            {% endfor %}
-          </select>
-          <div id="updateStatusHelp" class="form-text">Please enter update status
-          here.</div>
-          {% if form.update_status.errors %}
-          <div class="invalid-feedback">
-            <ul class="errors">
-              {% for error in form.update_status.errors %}
-                 <li>{{ error }}</li>
-              {% endfor %}
-            </ul>
-          </div>
+      <div class="mb-3">
+        <label for="{{form.update_status.id}}" class="form-label">{{form.update_status.label}}</label>
+        <select
+            class="form-select form-select-sm mb-3
+                   {% if form.update_status.errors %}is-invalid{% endif %}
+                    "
+            aria-label=".form-select-sm"
+            id="{{form.update_status.id}}"
+            name="{{form.update_status.name}}">
+          <option>Choose...</option>
+          {% for (k, v) in form.update_status.choices %}
+          <option
+          {% if form.update_status.data and k|string in form.update_status.data %} selected
           {% endif %}
-        </div>
-
-        <div class="mb-3">
-          <label for="{{form.next_update.id}}" class="form-label">{{form.next_update.label}}</label>
-          <input class="form-control
-                        {% if form.next_update.errors %}is-invalid{% endif %}"
-                type="datetime-local"
-                id="{{form.next_update.id}}"
-                name="{{form.next_update.name}}"
-                value="{{form.next_update.data}}"
-                aria-describedby="nextUpdateHelp"/>
-          <div id="nextUpdateHelp" class="form-text">
-            Please provide the time for the next expected update.</div>
-          {% if form.next_update.errors %}
-          <div class="invalid-feedback">
-            <ul class="errors">
-            {% for error in form.next_update.errors %}
-              <li>{{ error }}</li>
+          value="{{k}}">{{v}}</option>
+          {% endfor %}
+        </select>
+        <div id="updateStatusHelp" class="form-text">Please enter update status
+        here.</div>
+        {% if form.update_status.errors %}
+        <div class="invalid-feedback">
+          <ul class="errors">
+            {% for error in form.update_status.errors %}
+               <li>{{ error }}</li>
             {% endfor %}
-            </ul>
-          </div>
-          {% endif %}
+          </ul>
         </div>
-      {% endif %}
+        {% endif %}
+      </div>
+      <div class="mb-3">
+        <label for="{{form.date_update.id}}" class="form-label">{{form.date_update.label}}</label>
+        <input class="form-control
+                      {% if form.date_update.errors %}is-invalid{% endif %}"
+              type="datetime-local"
+              id="{{form.date_update.id}}"
+              name="{{form.date_update.name}}"
+              value="{{form.date_update.data}}"
+              aria-describedby="nextUpdateHelp"/>
+        <div id="nextUpdateHelp" class="form-text">
+          Please provide the time for the next expected update.</div>
+        {% if form.date_update.errors %}
+        <div class="invalid-feedback">
+          <ul class="errors">
+          {% for error in form.date_update.errors %}
+            <li>{{ error }}</li>
+          {% endfor %}
+          </ul>
+        </div>
+        {% endif %}
+      </div>
       <button type="submit" class="btn btn-primary">Submit</button>
 
       </form>


### PR DESCRIPTION
Changes affect work with incident status forms:

forms of incident editing and creating

The moment when, when creating a scheduled maintenance, 
a component was automatically moved from an open incident was removed, 
but still present in the opposit case.

Added options:

- changed
- reopened

First allows to change the time of the end of the incident,
but limited by timestamps of the existing statuses and conditions:
(not possible to change when new time less than the start of the incident and cannot be selected in the future)

Second allows to reopen the resolved incident with current timestamp